### PR TITLE
Autostart Stimulus.Application

### DIFF
--- a/vendor/assets/javascripts/stimulus.js.erb
+++ b/vendor/assets/javascripts/stimulus.js.erb
@@ -1,1 +1,3 @@
 <%= require_asset 'dist/stimulus.umd.js' %>
+
+window.application = Stimulus.Application.start()


### PR DESCRIPTION
Stimulus applications require invoking `Stimulus.Application.start()` on
the client side, and registering controllers with the resulting context
object.  This patch invokes the start method automatically, and assigns
the context object to `window.application` (or `@application` in
CoffeeScript).  Thus the context object is available in any JavaScript
ES6 file to register a controller like so:

  window.application.register("foo", class extends Stimulus.Controller { ... })

The variable name `application` was chosen because it seems to be the
standard name chosen in existing Stimulus.js examples.